### PR TITLE
fix for inline images in ImageScanner

### DIFF
--- a/src/PdfLexer.ImageSharpExts/PdfLexer.ImageSharpExts.csproj
+++ b/src/PdfLexer.ImageSharpExts/PdfLexer.ImageSharpExts.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/PdfLexer/Content/GfxState.cs
+++ b/src/PdfLexer/Content/GfxState.cs
@@ -40,6 +40,8 @@ public record GfxState<T> where T : struct, IFloatingPoint<T>
     public d_Op<T>? Dashing { get; init; }
     public PdfName? RenderingIntent { get; init; }
 
+    public GfxMatrix<T> TRM { get => Text.TextRenderingMatrix; }
+
 
     // TODO color model and replace existing
     internal IColorSpace ColorSpaceModel { get; init; } = DeviceGray.Instance;

--- a/src/PdfLexer/Content/ImageScanner.cs
+++ b/src/PdfLexer/Content/ImageScanner.cs
@@ -48,6 +48,7 @@ public ref struct ImageScanner
                     }
                     continue;
                 case PdfOperatorType.BI:
+                case PdfOperatorType.EI:
                     return true;
                 case PdfOperatorType.Do:
                     if (TryGetXObjImage(out lastDoImg))
@@ -63,7 +64,7 @@ public ref struct ImageScanner
 
     public bool TryGetImage([NotNullWhen(true)] out PdfImage image)
     {
-        if (Scanner.CurrentOperator == PdfOperatorType.BI)
+        if (Scanner.CurrentOperator == PdfOperatorType.BI || Scanner.CurrentOperator == PdfOperatorType.EI)
         {
             if (!Scanner.TryGetCurrentOperation(out var gso))
             {

--- a/src/PdfLexer/Content/SimpleWordScanner.cs
+++ b/src/PdfLexer/Content/SimpleWordScanner.cs
@@ -60,6 +60,8 @@ public ref struct SimpleWordScanner
     private PdfPoint<double>? prevPt;
     private double pw;
     private GfxMatrix<double> prev;
+    private GfxMatrix<double> prevTTM;
+    private GfxMatrix<double> lastTTM;
     private readonly StringBuilder sb;
 
     public PdfRect<double> GetWordBoundingBox()
@@ -109,9 +111,10 @@ public ref struct SimpleWordScanner
         {
             var vert = Scanner.GraphicsState.Font?.IsVertical ?? false;
             var current = Scanner.GraphicsState.Text.TextMatrix;
+            
             if (first == null)
             {
-                Position = current;
+                Position = Scanner.GraphicsState.Text.TextRenderingMatrix;
                 first ??= Scanner.GetCurrentBoundingBox();
                 firstPt ??= Scanner.GetCurrentTextPoint();
             }
@@ -124,6 +127,7 @@ public ref struct SimpleWordScanner
                     sb.Clear();
                     last = prevbb;
                     lastPt = prevPt;
+                    lastTTM = prevTTM;
                     returnWord = true;
                 }
                 else
@@ -164,6 +168,7 @@ public ref struct SimpleWordScanner
                         sb.Clear();
                         last = prevbb;
                         lastPt = prevPt;
+                        lastTTM = prevTTM;
                         prevbb = null;
                         prevPt = null;
                         return true;
@@ -186,6 +191,7 @@ public ref struct SimpleWordScanner
             prev = current;
             prevbb = Scanner.GetCurrentBoundingBox();
             prevPt = Scanner.GetCurrentTextPoint();
+            prevTTM = Scanner.GraphicsState.Text.TextMatrix;
             if (returnWord)
             {
                 if (CurrentWord.Length > 0)
@@ -201,6 +207,7 @@ public ref struct SimpleWordScanner
             sb.Clear();
             last = prevbb;
             lastPt = prevPt;
+            lastTTM = prevTTM;
             return true;
         }
 
@@ -216,4 +223,6 @@ public ref struct SimpleWordScanner
             BoundingBox = pos,
         };
     }
+
+    public GfxMatrix<double> GetCurrentWordMatrix() => lastTTM;
 }

--- a/src/PdfLexer/PdfLexer.csproj
+++ b/src/PdfLexer/PdfLexer.csproj
@@ -33,11 +33,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="DotNext.Unsafe">
-			<Version>4.10.0</Version>
+			<Version>4.14.0</Version>
 		</PackageReference>
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
-		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
-		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+		<PackageReference Include="System.IO.Pipelines" Version="9.0.0" />
+		<PackageReference Include="System.Numerics.Vectors" Version="4.6.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/PdfLexer/PdfLexer.csproj
+++ b/src/PdfLexer/PdfLexer.csproj
@@ -36,7 +36,7 @@
 			<Version>4.14.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-		<PackageReference Include="System.IO.Pipelines" Version="9.0.0" />
+		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
 		<PackageReference Include="System.Numerics.Vectors" Version="4.6.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Recent changes in content lexing changed behavior for how inline images are returned from the scanner. This updates the `ImageScanner` for those changes to return inline images properly.